### PR TITLE
Add Spacing between Social Media Ico and Title Left

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -171,6 +171,7 @@ a:hover {
 }
 
 .title-left {
+  margin-top: 15px;
   font-size: 2rem;
   position: relative;
 }
@@ -215,7 +216,7 @@ a:hover {
   font-size: 1.7rem;
   border-radius: 50%;
   line-height: 1.4;
-  margin: 0 15px 0 0;
+  margin: 15px 15px 0 0;
   box-shadow: 0 0 0 3px #0078ff;
   transition: all 500ms ease;
 }


### PR DESCRIPTION
I added spacing between social media ico and title left. its okay when you use mobile. but, in desktop mode there are no spacing.